### PR TITLE
Swap Mail facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ Trigger email failures to assert what happens on your Laravel Application when a
 
 ## Usage
 
-Once the `mailer` instance is replaced, all emails will fail. This helps to assert that your application Mail exceptions are handled correctly (ie: mark the email address as invalid)
+Once MailFailer instance is binded, all emails will fail. This helps to assert that your application Mail exceptions are handled correctly (ie: mark the email address as invalid)
 
 ```php
+class MyService
+{
+    public static function sendEmail()
+    {
+        \Illuminate\Support\Facades\Mail::send(...);
+    }
+}
+
 public function test_happy_path()
 {
     Mail::fake();
@@ -34,8 +42,9 @@ public function test_happy_path()
 
 public function test_email_failures()
 {
-    $mailer = new \LaravelEmailFailer\MailFailer;
-    $this->app->instance('mailer', $mailer);
+    $this->expectException(TransportException::class);
+
+    \LaravelEmailFailer\MailFailer::bind();
 
     MyService::sendEmail();
 

--- a/src/MailFailer.php
+++ b/src/MailFailer.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Mail\MailManager;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Throwable;
@@ -57,5 +58,12 @@ class MailFailer extends MailFake
     public function failures()
     {
         return $this->failedRecipients;
+    }
+
+    public static function bind(?Application $app = null): self
+    {
+        Mail::swap($instance = new self($app));
+
+        return $instance;
     }
 }


### PR DESCRIPTION
Simplify instantiation by swapping Mail Facade via `MailFailer::bind()` 